### PR TITLE
implement quiz state persistence with sessionStorage and resume functionality

### DIFF
--- a/scripts/quiz.js
+++ b/scripts/quiz.js
@@ -34,6 +34,11 @@ let timer = null;
 let timeLeft = 60; // 60 seconds per quiz
 let selectedOption = null;
 
+// Track selected answers for all questions (for persistence)
+let selectedAnswers = {};
+// Track which questions have already been scored (prevents double-increment)
+let answeredQuestions = new Set();
+
 // DOM elements
 const courseSelection = document.getElementById('courseSelection');
 const quizContainer = document.getElementById('quizContainer');
@@ -51,6 +56,53 @@ const finalScore = document.getElementById('finalScore');
 const timeTaken = document.getElementById('timeTaken');
 const correctAnswers = document.getElementById('correctAnswers');
 const incorrectAnswers = document.getElementById('incorrectAnswers');
+
+// ===== Quiz State Persistence Functions =====
+
+// Save current quiz state to sessionStorage
+function saveQuizState() {
+    if (!currentQuiz) return;
+    
+    const state = {
+        course: currentQuiz.title ? Object.keys(quizData).find(key => quizData[key].title === currentQuiz.title) : null,
+        currentQuestionIndex: currentQuestionIndex,
+        score: score,
+        timeLeft: timeLeft,
+        selectedAnswers: selectedAnswers,
+        answeredQuestions: Array.from(answeredQuestions)
+    };
+    
+    try {
+        sessionStorage.setItem('quizState', JSON.stringify(state));
+    } catch (error) {
+        console.warn('Could not save quiz state:', error);
+    }
+}
+
+// Restore quiz state from sessionStorage
+function restoreQuizState() {
+    try {
+        const savedState = sessionStorage.getItem('quizState');
+        if (!savedState) return null;
+        
+        const state = JSON.parse(savedState);
+        if (state && state.course && quizData[state.course]) {
+            return state;
+        }
+    } catch (error) {
+        console.warn('Could not restore quiz state:', error);
+    }
+    return null;
+}
+
+// Clear quiz state from sessionStorage
+function clearQuizState() {
+    try {
+        sessionStorage.removeItem('quizState');
+    } catch (error) {
+        console.warn('Could not clear quiz state:', error);
+    }
+}
 
 // Event listeners for quiz buttons
 document.querySelectorAll('.start-quiz').forEach(button => {
@@ -70,7 +122,46 @@ if (retryButton) retryButton.addEventListener('click', () => {
 if (backButton) backButton.addEventListener('click', () => {
     if (resultsContainer) resultsContainer.style.display = 'none';
     if (courseSelection) courseSelection.style.display = 'block';
+    clearQuizState();
 });
+
+// ===== Auto-Resume Quiz Session =====
+// Check for incomplete quiz on page load
+function checkAndResumeQuiz() {
+    const savedState = restoreQuizState();
+    if (savedState && savedState.course) {
+        // Show resume prompt
+        const resume = confirm('Resume your previous quiz attempt?');
+        if (resume) {
+            // Restore the previous quiz session
+            currentQuiz = quizData[savedState.course];
+            currentQuestionIndex = savedState.currentQuestionIndex;
+            score = savedState.score;
+            timeLeft = savedState.timeLeft;
+            selectedAnswers = savedState.selectedAnswers || {};
+            answeredQuestions = new Set(savedState.answeredQuestions || []);
+            
+            // Start quiz from restored state
+            if (courseSelection) courseSelection.style.display = 'none';
+            if (quizContainer) quizContainer.style.display = 'block';
+            if (resultsContainer) resultsContainer.style.display = 'none';
+            
+            const quizTitleEl = document.getElementById('quizTitle');
+            if (quizTitleEl && currentQuiz && currentQuiz.title) quizTitleEl.textContent = currentQuiz.title;
+            
+            updateTimer();
+            updateScore();
+            showQuestion();
+            startTimer();
+        } else {
+            // User declined, clear the saved state
+            clearQuizState();
+        }
+    }
+}
+
+// Check and restore on page load
+window.addEventListener('load', checkAndResumeQuiz);
 
 // Start quiz function
 function startQuiz(course) {
@@ -79,6 +170,8 @@ function startQuiz(course) {
     score = 0;
     timeLeft = 60;
     selectedOption = null;
+    selectedAnswers = {}; // Reset for new quiz
+    answeredQuestions = new Set(); // Reset for new quiz
 
     if (courseSelection) courseSelection.style.display = 'none';
     if (quizContainer) quizContainer.style.display = 'block';
@@ -90,6 +183,9 @@ function startQuiz(course) {
     updateScore();
     showQuestion();
     startTimer();
+    
+    // Save initial state
+    saveQuizState();
 }
 
 // Show current question
@@ -121,27 +217,35 @@ function showQuestion() {
 // Select option
 function selectOption(index) {
     selectedOption = index;
+    selectedAnswers[currentQuestionIndex] = index; // Save answer for this question
+    
     document.querySelectorAll('.option').forEach(option => {
         option.classList.remove('selected');
     });
     const el = document.querySelector(`.option[data-index="${index}"]`);
     if (el) el.classList.add('selected');
 
-    // Update score if correct
+    // Only increment score if this question hasn't been scored yet
     if (currentQuiz && currentQuiz.questions && currentQuiz.questions[currentQuestionIndex]) {
-        if (index === currentQuiz.questions[currentQuestionIndex].correct) {
+        if (index === currentQuiz.questions[currentQuestionIndex].correct && 
+            !answeredQuestions.has(currentQuestionIndex)) {
+            answeredQuestions.add(currentQuestionIndex);
             score++;
             updateScore();
         }
     }
+    
+    // Save state after selection
+    saveQuizState();
 }
 
 // Next question
 function nextQuestion() {
     if (currentQuestionIndex < currentQuiz.questions.length - 1) {
         currentQuestionIndex++;
-        selectedOption = null;
+        selectedOption = selectedAnswers[currentQuestionIndex] || null;
         showQuestion();
+        saveQuizState(); // Save after navigation
     }
 }
 
@@ -149,8 +253,9 @@ function nextQuestion() {
 function previousQuestion() {
     if (currentQuestionIndex > 0) {
         currentQuestionIndex--;
-        selectedOption = null;
+        selectedOption = selectedAnswers[currentQuestionIndex] || null;
         showQuestion();
+        saveQuizState(); // Save after navigation
     }
 }
 
@@ -168,6 +273,9 @@ function submitQuiz() {
     timeTaken.textContent = `${60 - timeLeft} seconds`;
     correctAnswers.textContent = correctCount;
     incorrectAnswers.textContent = incorrectCount;
+    
+    // Clear quiz state after successful submission
+    clearQuizState();
 }
 
 // Update timer


### PR DESCRIPTION
## Description

Implemented quiz state persistence using sessionStorage to enable users to resume their quiz 
attempts after page refresh or accidental browser closure. The feature automatically detects 
incomplete quiz sessions and prompts users to resume with all progress preserved (current 
question, selected answers, score, and remaining time).

### Key Changes:
- **State Persistence:** Added three helper functions (`saveQuizState()`, `restoreQuizState()`, 
  `clearQuizState()`) to manage quiz state in sessionStorage
- **Answer Tracking:** Introduced `selectedAnswers` object to persist answers across all questions 
  during quiz navigation
- **Score Integrity:** Added `answeredQuestions` Set to prevent duplicate score increments caused 
  by answer reselection or page navigation
- **Resume Detection:** Implemented automatic session detection on page load with user-friendly 
  resume confirmation prompt
- **State Restoration:** Seamlessly restores quiz state (question index, answers, score, timer) 
  when user accepts resume prompt
- **Automatic Cleanup:** Clears persisted state after quiz submission and when navigating back to 
  course selection

### Files Modified:
- `scripts/quiz.js` – Added persistence logic and enhanced state management

## Related Issue

Closes #20 

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI improvement
- [ ] Model improvement

## Testing Instructions

1. Start a quiz and answer 2-3 questions
2. Refresh the page (F5 or Ctrl+R)
3. Accept the "Resume your previous quiz attempt?" prompt
4. Verify that:
   - Current question index is restored
   - Previously selected answers are highlighted
   - Score is preserved
   - Timer continues from where it left off
5. Navigate to previous/next questions and verify answer persistence
6. Complete the quiz and refresh – verify state is cleared
7. Start a new quiz and refresh – verify only the new quiz session is saved

## Screenshots / Demo

<img width="1366" height="768" alt="Screenshot (225)" src="https://github.com/user-attachments/assets/56ea5560-5ba7-45fe-b290-f2c38bb1755e" />


## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project guidelines
- [x] I have only worked on the assigned issue
- [x] No external dependencies added
- [x] Existing functionality is preserved
- [x] Error handling implemented with try-catch blocks
- [x] Code changes are minimal and focused

## Notes

- Changes use only native browser APIs (sessionStorage)
- Fully backwards compatible with existing quiz system
- No UI/UX modifications – feature is transparent to users
- Comprehensive error handling prevents sessionStorage quota issues
- All existing quiz functions maintain their original signatures