### PR TITLE
feat: add stats section with count-up animation

### DIFF
--- a/Styles/main.css
+++ b/Styles/main.css
@@ -1145,3 +1145,26 @@ ul li i.fa-check {
         margin: 10% auto;
     }
 } 
+/* Stats Section */
+
+.stats-section {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  padding: 3rem 2rem;
+  background-color: var(--primary-color, #2c3e50);
+  text-align: center;
+}
+
+.stat-item h3 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #2c3e50;
+  margin-bottom: 0.5rem;
+}
+
+.stat-item p {
+  font-size: 1rem;
+  color: #555;
+}

--- a/index.html
+++ b/index.html
@@ -59,6 +59,25 @@
       <a href="#courses" class="btn">Explore Courses</a>
     </section>
 
+    <!-- Stats Section -->
+<section class="stats-section">
+  <div class="stat-item">
+    <h3 data-target="500" data-suffix="+">0</h3>
+    <p>Students Enrolled</p>
+  </div>
+  <div class="stat-item">
+    <h3 data-target="3" data-suffix="">0</h3>
+    <p>Courses Available</p>
+  </div>
+  <div class="stat-item">
+    <h3 data-target="100" data-suffix="%">0</h3>
+    <p>Free Forever</p>
+  </div>
+  <div class="stat-item">
+    <h3 data-target="24" data-suffix="/7">0</h3>
+    <p>AI Chatbot Support</p>
+  </div>
+</section>
     <!-- Featured Courses -->
     <section id="courses" class="section">
       <h2>Featured Courses</h2>
@@ -243,7 +262,7 @@
 
     // Load chatbot when the page is ready
     document.addEventListener('DOMContentLoaded', loadChatbot);
-  </script>
+  </script> 
 </body>
 </html>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -270,4 +270,40 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     }
+}); 
+
+// Count-up Animation
+document.addEventListener('DOMContentLoaded', () => {
+  function countUp(element, target, duration = 2000) {
+    let start = 0;
+    const increment = target / (duration / 16);
+
+    const timer = setInterval(() => {
+      start += increment;
+      if (start >= target) {
+        element.textContent = target + (element.dataset.suffix || '');
+        clearInterval(timer);
+      } else {
+        element.textContent = Math.floor(start) + (element.dataset.suffix || '');
+      }
+    }, 16);
+  }
+
+  const statsSection = document.querySelector('.stats-section');
+
+  if (statsSection) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          document.querySelectorAll('.stat-item h3').forEach(el => {
+            const target = parseInt(el.dataset.target);
+            countUp(el, target);
+          });
+          observer.disconnect(); // only animate once
+        }
+      });
+    });
+
+    observer.observe(statsSection);
+  }
 });


### PR DESCRIPTION
Added a Stats Section to the homepage that displays key platform 
highlights like Students Enrolled, Courses Available, Free Forever, 
and AI Chatbot Support.

#Changes
- Added Stats Section in index.html after the Hero section
- Added CSS styles in Styles/main.css for the stats layout
- Added count-up animation in scripts/main.js using IntersectionObserver 

Fix #51 

<img width="1000" height="500" alt="Screenshot (194)" src="https://github.com/user-attachments/assets/846d436a-fa0f-4a07-85c7-d38fd2806168" />

