### PR TITLE
Add backend requirements, .env.example; make app tolerant of missing …

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ cd EduBridge
 ```bash
 python3 -m venv venv
 source venv/bin/activate   # macOS/Linux
+venv\Scripts\activate     # Windows (PowerShell/CMD)
 pip install -r backend/requirements.txt
 ```
 3️⃣ Create your env file
@@ -117,6 +118,8 @@ http://127.0.0.1:8000/index.html
 ```
 
 **✅ Important:**
+Run the remaining backend commands inside the activated virtual environment.
+
 The chatbot frontend will call the backend at `http://127.0.0.1:5000/chat`. If `OPENAI_API_KEY` is not set the backend will return a clear error message and the frontend will fall back to a local response mode.
 
 ---

--- a/README.md
+++ b/README.md
@@ -90,31 +90,34 @@ EduBridge/
 
 1️⃣ Clone the repository
 ```bash
-  git clone https://github.com/AditixAnand/EduBridge.git
-  cd EduBridge
+git clone https://github.com/AditixAnand/EduBridge.git
+cd EduBridge
 ```
-2️⃣ Setup Python Backend
+2️⃣ Setup Python Backend (recommended)
 ```bash
-  cd backend
-  pip install flask python-dotenv openai
+python3 -m venv venv
+source venv/bin/activate   # macOS/Linux
+pip install -r backend/requirements.txt
 ```
-💡 Recommended: Use a virtual environment:
+3️⃣ Create your env file
 ```bash
-  python -m venv venv
-  venv\Scripts\activate   # Windows
-  source venv/bin/activate # macOS/Linux
+cp backend/.env.example backend/.env
+# Edit backend/.env and add your OPENAI_API_KEY
 ```
-3️⃣ Run the Backend
+4️⃣ Run the Backend
 ```bash
-  python app.py
+python backend/app.py
 ```
-4️⃣ Open the Frontend  
-  Open index.html in your browser.  
-**✅ Important:**  
-Ensure JavaScript API calls point to:  
-```bash
-http://127.0.0.1:5000/
+5️⃣ Open the Frontend
+
+Open `index.html` in your browser or serve the project root with a static server (e.g. `python -m http.server 8000`) and navigate to:
+
 ```
+http://127.0.0.1:8000/index.html
+```
+
+**✅ Important:**
+The chatbot frontend will call the backend at `http://127.0.0.1:5000/chat`. If `OPENAI_API_KEY` is not set the backend will return a clear error message and the frontend will fall back to a local response mode.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to `backend/.env` and replace the placeholder with your actual key.
+OPENAI_API_KEY=your_openai_api_key_here

--- a/backend/app.py
+++ b/backend/app.py
@@ -13,19 +13,30 @@ app = Flask(__name__)
 # This allows your frontend (running on a different port/Live Server) to talk to this backend
 CORS(app)
 
-# Note: Do not initialize the OpenAI client at import time. Read the API key
-# inside the request handler so the server can start even if the key is missing.
+# Lazy singleton for OpenAI client to avoid per-request allocations but still
+# allow the server to start when the API key is not yet configured.
+_openai_client = None
+
+def get_openai_client():
+    global _openai_client
+    if _openai_client is not None:
+        return _openai_client
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    _openai_client = OpenAI(api_key=api_key)
+    return _openai_client
 
 @app.route('/chat', methods=['POST'])
 def chat():
-    # Read API key at request time
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        # Return a clear error so the server doesn't crash on startup when the key is missing
-        return jsonify({"error": "OpenAI API key is missing. Please set OPENAI_API_KEY in backend/.env or environment."}), 500
-
-    # Initialize client per-request using the available key
-    client = OpenAI(api_key=api_key)
+    # Obtain a client (lazy). If missing, return a generic service-unavailable error.
+    client = get_openai_client()
+    if client is None:
+        # Log a helpful message server-side (do not expose file paths to clients)
+        print("OpenAI API key is not configured. Set OPENAI_API_KEY in backend/.env or environment to enable AI features.")
+        return jsonify({"error": "AI service not configured"}), 503
 
     # Get the message from the frontend
     data = request.get_json()

--- a/backend/app.py
+++ b/backend/app.py
@@ -13,16 +13,19 @@ app = Flask(__name__)
 # This allows your frontend (running on a different port/Live Server) to talk to this backend
 CORS(app)
 
-# 3. Initialize the OpenAI client securely
-# It automatically looks for "OPENAI_API_KEY" in your environment variables
-api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=api_key)
+# Note: Do not initialize the OpenAI client at import time. Read the API key
+# inside the request handler so the server can start even if the key is missing.
 
 @app.route('/chat', methods=['POST'])
 def chat():
-    # Security check: Ensure API key is loaded
+    # Read API key at request time
+    api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        return jsonify({"error": "OpenAI API key is missing. Check your .env file."}), 500
+        # Return a clear error so the server doesn't crash on startup when the key is missing
+        return jsonify({"error": "OpenAI API key is missing. Please set OPENAI_API_KEY in backend/.env or environment."}), 500
+
+    # Initialize client per-request using the available key
+    client = OpenAI(api_key=api_key)
 
     # Get the message from the frontend
     data = request.get_json()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+flask
+python-dotenv
+openai
+flask-cors

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,7 @@
-flask
-python-dotenv
-openai
-flask-cors
+
+# Pinned backend dependencies for reproducible installs
+Flask==3.1.3
+python-dotenv==1.2.2
+openai==2.37.0
+Flask-Cors==6.0.2
+


### PR DESCRIPTION
Adds a reproducible local setup for the Python backend and prevents committing secret keys.
Makes the Flask backend start even when OPENAI_API_KEY is not set by initializing the OpenAI client per-request and returning a clear JSON error if the key is missing.

Why this helps

Contributors can now install dependencies via pip install -r backend/requirements.txt.
No accidental secret commits — .envis ignored by .gitignore
Dev server starts reliably even when an API key is not present, improving DX and enabling frontend development without keys (frontend falls back to local responses).

Author: @goyaljiiiiii
Reference issue: #86 