### PR TITLE
feat: scoped CORS config, requirements.txt and verification tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,27 +88,48 @@ EduBridge/
 
 ## ⚙️ Setup Instructions
 
-1️⃣ Clone the repository
+### 1. Clone the repository
 ```bash
   git clone https://github.com/AditixAnand/EduBridge.git
   cd EduBridge
 ```
-2️⃣ Setup Python Backend
+### 2. Setup Python Backend
+
 ```bash
-  cd backend
-  pip install flask python-dotenv openai
+cd backend
+python -m venv venv
+source venv/bin/activate     # macOS/Linux
+# venv\Scripts\activate      # Windows
+pip install -r requirements.txt
+cp .env.example .env         # then fill in the OPENAI_API_KEY field
 ```
-💡 Recommended: Use a virtual environment:
+
+### 3. Run the Backend
+
 ```bash
-  python -m venv venv
-  venv\Scripts\activate   # Windows
-  source venv/bin/activate # macOS/Linux
+python app.py
 ```
-3️⃣ Run the Backend
+
+The backend runs on `http://127.0.0.1:5000`. The frontend (Live Server on port 5500, or opened directly via `file://`) is whitelisted by default. To allow additional origins, set `CORS_ALLOWED_ORIGINS` in `.env` as a comma-separated list.
+
+### 4. Verify
+
 ```bash
-  python app.py
+# Replace 'curl' with 'curl.exe' in Windows
+# Health check
+curl -i http://127.0.0.1:5000/health
+
+# Chat endpoint (requires a valid OPENAI_API_KEY)
+curl -i -X POST http://127.0.0.1:5000/chat \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://127.0.0.1:5500" \
+  -d '{"message": "Hello"}'
+
+# Run the test suite
+pip install pytest
+pytest backend/tests -q
 ```
-4️⃣ Open the Frontend  
+### 5. Open the Frontend  
   Open index.html in your browser.  
 **✅ Important:**  
 Ensure JavaScript API calls point to:  

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to `.env` and fill in real values. `.env` is gitignored.
+
+# Required: OpenAI API key (https://platform.openai.com/api-keys)
+OPENAI_API_KEY=
+
+# Optional: comma-separated list of allowed CORS origins.
+# Defaults to common local dev origins if unset:
+#   http://localhost:5500, http://127.0.0.1:5500,
+#   http://localhost:5000, http://127.0.0.1:5000, null
+# Example for production:
+#   CORS_ALLOWED_ORIGINS=https://edubridge.example.com,https://www.edubridge.example.com
+CORS_ALLOWED_ORIGINS=

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,56 +1,103 @@
 import os
-from flask import Flask, request, jsonify
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from openai import OpenAI
-from dotenv import load_dotenv
 
-# 1. Load environment variables from .env file
+# Load environment variables from .env file
 load_dotenv()
 
 app = Flask(__name__)
 
-# 2. Enable CORS (Cross-Origin Resource Sharing)
-# This allows your frontend (running on a different port/Live Server) to talk to this backend
-CORS(app)
+# -----------------------------------------------------------------------------
+# CORS configuration
+# -----------------------------------------------------------------------------
+# The frontend (index.html, ai.html, etc.) is typically served from a different
+# origin than this Flask backend during development:
+#   - VS Code Live Server: http://127.0.0.1:5500 (or http://localhost:5500)
+#   - opened directly from disk: origin is "null"
+#   - Flask backend itself:  http://127.0.0.1:5000
+#
+# Allowed origins can be overridden via the CORS_ALLOWED_ORIGINS env var as a
+# comma-separated list, e.g.
+#   CORS_ALLOWED_ORIGINS="https://edubridge.example.com,https://staging.example.com"
+#
+# Scope is limited to /chat and /health (the only endpoints the frontend hits)
+# and to the methods we actually use, so we don't widen access unnecessarily.
+# -----------------------------------------------------------------------------
+_DEFAULT_ORIGINS = [
+    "http://localhost:5500",
+    "http://127.0.0.1:5500",
+    "http://localhost:5000",
+    "http://127.0.0.1:5000",
+    "null",  # index.html opened directly via file:// during development
+]
+_env_origins = os.getenv("CORS_ALLOWED_ORIGINS", "").strip()
+allowed_origins = (
+    [o.strip() for o in _env_origins.split(",") if o.strip()]
+    if _env_origins
+    else _DEFAULT_ORIGINS
+)
 
-# 3. Initialize the OpenAI client securely
-# It automatically looks for "OPENAI_API_KEY" in your environment variables
+CORS(
+    app,
+    resources={
+        r"/chat": {"origins": allowed_origins},
+        r"/health": {"origins": allowed_origins},
+    },
+    methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type"],
+    max_age=86400,  # cache preflight for 1 day
+)
+
+# -----------------------------------------------------------------------------
+# OpenAI client
+# -----------------------------------------------------------------------------
 api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=api_key)
+client = OpenAI(api_key=api_key) if api_key else None
 
-@app.route('/chat', methods=['POST'])
+
+@app.route("/health", methods=["GET"])
+def health():
+    """Lightweight liveness check. Does not call OpenAI, safe to ping freely."""
+    return jsonify({"status": "ok"}), 200
+
+
+@app.route("/chat", methods=["POST"])
 def chat():
-    # Security check: Ensure API key is loaded
-    if not api_key:
+    # Security check: ensure API key is loaded
+    if not api_key or client is None:
         return jsonify({"error": "OpenAI API key is missing. Check your .env file."}), 500
 
     # Get the message from the frontend
-    data = request.get_json()
-    user_message = data.get('message')
-    
+    data = request.get_json(silent=True) or {}
+    user_message = data.get("message")
+
     if not user_message:
         return jsonify({"error": "No message provided"}), 400
 
     try:
-        # 4. Use the new Chat Completions API (v1.x syntax)
-        # Using gpt-3.5-turbo (faster & cheaper than davinci)
         response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
-                {"role": "system", "content": "You are a helpful assistant for EduBridge, an online learning platform."},
-                {"role": "user", "content": user_message}
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant for EduBridge, an online learning platform.",
+                },
+                {"role": "user", "content": user_message},
             ],
             max_tokens=150,
-            temperature=0.7
+            temperature=0.7,
         )
-        
-        # 5. Access the response using the new v1.x object structure
+
         ai_response = response.choices[0].message.content.strip()
         return jsonify({"response": ai_response})
 
     except Exception as e:
-        print(f"Error: {e}")  # Print to console for debugging
+        app.logger.exception("OpenAI call failed")
         return jsonify({"error": str(e)}), 500
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0,<4.0
+flask-cors>=4.0,<6.0
+openai>=1.0,<2.0
+python-dotenv>=1.0,<2.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration: make `app` importable from the backend/ directory."""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BACKEND_DIR = os.path.dirname(HERE)
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,102 @@
+"""
+Tests for CORS support on the Flask backend.
+
+Verifies issue #11 acceptance criteria: the frontend (running on a different
+origin) can successfully send POST requests to /chat.
+
+Run from the repo root:
+    pip install -r backend/requirements.txt
+    pip install pytest
+    pytest backend/tests -q
+"""
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+ALLOWED_ORIGIN = "http://127.0.0.1:5500"
+DISALLOWED_ORIGIN = "http://evil.example.com"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Provide a fake API key so the app initializes its OpenAI client.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv(
+        "CORS_ALLOWED_ORIGINS",
+        f"{ALLOWED_ORIGIN},http://localhost:5500",
+    )
+    # Import after env vars are set so module-level config picks them up.
+    import app as app_module  # noqa: WPS433  (path is set in conftest.py)
+    importlib.reload(app_module)
+    app_module.app.config["TESTING"] = True
+    return app_module.app.test_client()
+
+
+def test_health_endpoint_is_reachable(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_preflight_from_allowed_origin_succeeds(client):
+    resp = client.options(
+        "/chat",
+        headers={
+            "Origin": ALLOWED_ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type",
+        },
+    )
+    assert resp.status_code in (200, 204)
+    assert resp.headers.get("Access-Control-Allow-Origin") == ALLOWED_ORIGIN
+    allow_methods = resp.headers.get("Access-Control-Allow-Methods", "")
+    assert "POST" in allow_methods
+
+
+def test_post_chat_from_allowed_origin_has_cors_header(client):
+    fake_completion = MagicMock()
+    fake_completion.choices = [MagicMock(message=MagicMock(content="hi from openai"))]
+
+    with patch("app.client") as mock_openai:
+        mock_openai.chat.completions.create.return_value = fake_completion
+
+        resp = client.post(
+            "/chat",
+            json={"message": "hello"},
+            headers={"Origin": ALLOWED_ORIGIN},
+        )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"response": "hi from openai"}
+    assert resp.headers.get("Access-Control-Allow-Origin") == ALLOWED_ORIGIN
+
+
+def test_post_chat_from_disallowed_origin_lacks_cors_header(client):
+    fake_completion = MagicMock()
+    fake_completion.choices = [MagicMock(message=MagicMock(content="hi"))]
+
+    with patch("app.client") as mock_openai:
+        mock_openai.chat.completions.create.return_value = fake_completion
+
+        resp = client.post(
+            "/chat",
+            json={"message": "hello"},
+            headers={"Origin": DISALLOWED_ORIGIN},
+        )
+
+    # CORS is a browser-enforced policy on responses, not a server-side block.
+    # The server still answers, but it must NOT advertise this origin as allowed,
+    # so the browser will refuse to expose the response to the page.
+    assert resp.headers.get("Access-Control-Allow-Origin") != DISALLOWED_ORIGIN
+
+
+def test_post_chat_missing_message_returns_400(client):
+    resp = client.post(
+        "/chat",
+        json={},
+        headers={"Origin": ALLOWED_ORIGIN},
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()


### PR DESCRIPTION
## Summary
Closes #11 

This feature enables CORS for the Flask backend so the frontend (served from a different origin in dev - Live Server on :5500, or `file://`) can call `/chat`.

Scope was limited to issue #11; the chat handler itself is unchanged aside from a logger nit.

## Changes
- **`backend/app.py`** — replaced the bare `CORS(app)` with a scoped config:
  - Limited to `/chat` and `/health`
  - Methods restricted to `GET, POST, OPTIONS`
  - Allowed origins default to common local-dev origins (incl. `"null"` for `file://`); override via the `CORS_ALLOWED_ORIGINS` environment variable
  - Pre-flight cached for 1 day (`max_age=86400`)
- **`backend/app.py`** — added `GET /health` returning `{"status": "ok"}` for cheap end-to-end verification (no OpenAI tokens spent).
- **`backend/requirements.txt`** — added (pins `flask`, `flask-cors`, `openai`, `python-dotenv`). `flask-cors` was previously imported but not listed anywhere, so contributors couldn't reproduce the env from the README.
- **`backend/.env.example`** — added, records `OPENAI_API_KEY` and `CORS_ALLOWED_ORIGINS`.
- **`backend/tests/`** — added pytest suite covering pre-flight from allowed origin, POST with ACAO header, disallowed origin/s not getting ACAO, `/health` reachability, and the 400 path. OpenAI is mocked so that tests run offline.
- **`README.md`** — updated setup steps to use `requirements.txt` and documented the verification curl commands.

## Verification

End-to-end, against a local run with `Origin: http://127.0.0.1:5500`:
- `GET /health` -> `200`, `Access-Control-Allow-Origin: http://127.0.0.1:5500`
- `OPTIONS /chat` (preflight) -> `200`, ACAO/ACAM/ACAH headers present
- `OPTIONS /chat` from `http://evil.example.com` -> no ACAO header (browser will block it, as intended)

Tests pass locally: `pytest backend/tests -q` -> 5 passed.

## Notes for review
The default origin list includes `"null"` because `index.html` is sometimes opened directly off disk during dev - without this, the chatbot's fetch request to `/chat` fails pre-flight. If that's undesirable for prod, drop it from `CORS_ALLOWED_ORIGINS` in the production `.env`.