### PR TITLE
fix: correct stylesheet link in resource pages (styles.css → main.css)

### DIFF
--- a/resources/ai.html
+++ b/resources/ai.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EduBridge | AI & Machine Learning</title>
-  <link rel="stylesheet" href="../Styles/styles.css" />
+  <link rel="stylesheet" href="../Styles/main.css" />
   <link rel="stylesheet" href="../Styles/chat.css" />
   <link rel="stylesheet" href="https://unpkg.com/aos@2.3.4/dist/aos.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />

--- a/resources/career.html
+++ b/resources/career.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>EduBridge | Career</title>
-  <link rel="stylesheet" href="../Styles/styles.css" />
+  <link rel="stylesheet" href="../Styles/main.css" />
   <link rel="stylesheet" href="../Styles/chat.css" />
   <link rel="stylesheet" href="https://unpkg.com/aos@2.3.4/dist/aos.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"/>

--- a/resources/webdev.html
+++ b/resources/webdev.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EduBridge | Web Development</title>
-  <link rel="stylesheet" href="../Styles/styles.css" />
+  <link rel="stylesheet" href="../Styles/main.css" />
   <link rel="stylesheet" href="../Styles/chat.css" />
   <link rel="stylesheet" href="https://unpkg.com/aos@2.3.4/dist/aos.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />


### PR DESCRIPTION
## Description\n\nThree resource pages linked to a non-existent `styles.css` file, causing them to render without styling.\n\n## Changes\n- Changed `../Styles/styles.css` → `../Styles/main.css` in `resources/webdev.html`, `resources/career.html`, and `resources/ai.html`\n\nCloses #94