### PR TITLE
Fix: Disable Flask debug mode in production

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -53,4 +53,4 @@ def chat():
         return jsonify({"error": str(e)}), 500
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=os.getenv("FLASK_DEBUG", "false").lower() == "true")


### PR DESCRIPTION
Fixes #115

### Changes Made
- Replaced `debug=True` with environment variable
- Debug mode is now OFF by default in production
- Developers can enable it locally by setting `FLASK_DEBUG=true`