### PR TITLE
fix: hardcoded API key placeholder, missing chatbot module, null auth-form crash

### DIFF
--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -121,7 +121,11 @@ function showMessage(type, message) {
     messageDiv.textContent = message;
 
     const form = document.querySelector('.auth-form');
-    form.insertAdjacentElement('beforebegin', messageDiv);
+    if (form) {
+        form.insertAdjacentElement('beforebegin', messageDiv);
+    } else {
+        document.body.appendChild(messageDiv);
+    }
 
     setTimeout(() => {
         messageDiv.remove();

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
 const path = require('path');
-const chatbotRouter = require('./chatbot');
+const chatbotRouter = require('./server');
 
 // Load environment variables
 dotenv.config();

--- a/server/server.js
+++ b/server/server.js
@@ -25,7 +25,7 @@ app.post('/chat', async (req, res) => {
       temperature: 0.7
     }, {
       headers: {
-        'Authorization': `Bearer YOUR_OPENAI_API_KEY` // Replace with your actual OpenAI API Key
+        'Authorization': `Bearer ${OPENAI_API_KEY}` // Replace with your actual OpenAI API Key
       }
     });
 


### PR DESCRIPTION
Real fixes:
1. server.js: hardcoded YOUR_OPENAI_API_KEY instead of using process.env.OPENAI_API_KEY
2. index.js: require('chatbot') module does not exist - startup crash
3. auth.js: null querySelector crashes showMessage() on pages without .auth-form